### PR TITLE
Update value to value_inc_vat in Octopus Energy Blueprint

### DIFF
--- a/_docs/blueprints/target_timeframes_octopus_energy.yaml
+++ b/_docs/blueprints/target_timeframes_octopus_energy.yaml
@@ -65,7 +65,7 @@ action:
     {% for rate in all_rates %}
     {% set start = rate["start"] | as_timestamp | timestamp_utc %}
     {% set end = rate["end"] | as_timestamp | timestamp_utc %}
-    {% set value = rate["value"] | float %}
+    {% set value = rate["value_inc_vat"] | float %}
     {% set data.new_rates = data.new_rates + [{ 'start': start , 'end': end, 'value': value, 'metadata': { "is_capped": rate["is_capped"] } }] %}
     {% endfor %}
     {{ { 'data': data.new_rates } }}


### PR DESCRIPTION
"value" has changed to "value_inc_vat" in return from Octopus API